### PR TITLE
Add one-to-one correspondence filtering

### DIFF
--- a/include/cilantro/correspondence_search_kd_tree.hpp
+++ b/include/cilantro/correspondence_search_kd_tree.hpp
@@ -34,7 +34,7 @@ namespace cilantro {
                   src_evaluation_features_adaptor_(src_features), evaluator_(evaluator),
                   search_dir_(CorrespondenceSearchDirection::SECOND_TO_FIRST),
                   max_distance_((CorrespondenceScalar)(0.01*0.01)),
-                  inlier_fraction_(1.0), require_reciprocality_(false)
+                  inlier_fraction_(1.0), require_reciprocality_(false), one_to_one_(false)
         {}
 
         CorrespondenceSearchKDTree(SearchFeatureAdaptorT &dst_search_features,
@@ -45,7 +45,7 @@ namespace cilantro {
                   src_evaluation_features_adaptor_(src_eval_features), evaluator_(evaluator),
                   search_dir_(CorrespondenceSearchDirection::SECOND_TO_FIRST),
                   max_distance_((CorrespondenceScalar)(0.01*0.01)),
-                  inlier_fraction_(1.0), require_reciprocality_(false)
+                  inlier_fraction_(1.0), require_reciprocality_(false), one_to_one_(false)
         {}
 
         CorrespondenceSearchKDTree& findCorrespondences() {
@@ -69,6 +69,8 @@ namespace cilantro {
             }
 
             filterCorrespondencesFraction(correspondences_, inlier_fraction_);
+            if (one_to_one_)
+                filterCorrespondencesOneToOne(correspondences_, search_dir_);
 
             return *this;
         }
@@ -145,6 +147,8 @@ namespace cilantro {
             }
 
             filterCorrespondencesFraction(correspondences_, inlier_fraction_);
+            if (one_to_one_)
+                filterCorrespondencesOneToOne(correspondences_, search_dir_);
 
             return *this;
         }
@@ -181,7 +185,14 @@ namespace cilantro {
             return *this;
         }
 
-    private:
+        inline bool getOneToOne() const { return one_to_one_;  }
+
+        inline CorrespondenceSearchKDTree& setOneToOne(bool one_to_one) {
+            one_to_one_ = one_to_one;
+            return *this;
+        }
+
+       private:
         SearchFeatureAdaptorT& dst_search_features_adaptor_;
         SearchFeatureAdaptorT& src_search_features_adaptor_;
 
@@ -197,6 +208,7 @@ namespace cilantro {
         CorrespondenceScalar max_distance_;
         double inlier_fraction_;
         bool require_reciprocality_;
+        bool one_to_one_;
 
         SearchResult correspondences_;
     };

--- a/include/cilantro/correspondence_search_kd_tree_utilities.hpp
+++ b/include/cilantro/correspondence_search_kd_tree_utilities.hpp
@@ -5,7 +5,6 @@
 #include <cilantro/kd_tree.hpp>
 
 namespace cilantro {
-    enum struct CorrespondenceSearchDirection {FIRST_TO_SECOND, SECOND_TO_FIRST, BOTH};
 
     template <typename ScalarT, ptrdiff_t EigenDim, template <class> class DistAdaptor = KDTreeDistanceAdaptors::L2, class EvaluatorT = DistanceEvaluator<ScalarT,ScalarT>, typename CorrValueT = typename EvaluatorT::OutputScalar>
     void findNNCorrespondencesUnidirectional(const ConstVectorSetMatrixMap<ScalarT,EigenDim> &query_pts,


### PR DESCRIPTION
This PR adds an optional one-to-one correspondence filter. This is useful near the edges of correspondence regions where often multiple points of the target map to the same source point. With the proposed filter we only keep the best correspondence.

Before/After proposed filter, where the green lines illustrate the correspondences (target points not visualized).

![image](https://user-images.githubusercontent.com/14992841/52697638-1cf36080-2f72-11e9-8a30-f140f0129b1b.png)

![image](https://user-images.githubusercontent.com/14992841/52697484-d7369800-2f71-11e9-8eb6-d24bcfdc5a62.png)
