### PR TITLE
Add symmetric transform estimation

### DIFF
--- a/include/cilantro/transform_estimation.hpp
+++ b/include/cilantro/transform_estimation.hpp
@@ -434,4 +434,121 @@ namespace cilantro {
 
         return has_point_to_point_terms*point_to_point_correspondences.size() + has_point_to_plane_terms*point_to_plane_correspondences.size() >= Dim + 1;
     }
+
+    // Rigid, combined symmetric metric, 3D, iterative
+    // For more details about this method see
+    // Szymon Rusinkiewicz. A Symmetric Objective Function for ICP. ACM Transactions on Graphics (Proc. SIGGRAPH) 38(4), July 2019.
+    template <class TransformT, class PointCorrWeightEvaluatorT = UnityWeightEvaluator<typename TransformT::Scalar,typename TransformT::Scalar>, class PlaneCorrWeightEvaluatorT = UnityWeightEvaluator<typename TransformT::Scalar,typename TransformT::Scalar>>
+    typename std::enable_if<int(TransformT::Mode) == int(Eigen::Isometry) && TransformT::Dim == 3,bool>::type
+    estimateTransformSymmetricMetric(const ConstVectorSetMatrixMap<typename TransformT::Scalar,3> &dst_p,
+                                     const ConstVectorSetMatrixMap<typename TransformT::Scalar,3> &dst_n,
+                                     const ConstVectorSetMatrixMap<typename TransformT::Scalar,3> &src_p,
+                                     const ConstVectorSetMatrixMap<typename TransformT::Scalar,3> &src_n,
+                                     const CorrespondenceSet<typename PointCorrWeightEvaluatorT::InputScalar> &point_to_point_correspondences,
+                                     typename TransformT::Scalar point_to_point_weight,
+                                     const CorrespondenceSet<typename PlaneCorrWeightEvaluatorT::InputScalar> &point_to_plane_correspondences,
+                                     typename TransformT::Scalar point_to_plane_weight,
+                                     TransformT &tform,
+                                     size_t max_iter = 1,
+                                     typename TransformT::Scalar convergence_tol = (typename TransformT::Scalar)1e-5,
+                                     const PointCorrWeightEvaluatorT &point_corr_evaluator = PointCorrWeightEvaluatorT(),
+                                     const PlaneCorrWeightEvaluatorT &plane_corr_evaluator = PlaneCorrWeightEvaluatorT())
+    {
+        typedef typename TransformT::Scalar ScalarT;
+
+        tform.setIdentity();
+
+        const bool has_point_to_point_terms = !point_to_point_correspondences.empty() && (point_to_point_weight > (ScalarT)0.0);
+        const bool has_point_to_plane_terms = !point_to_plane_correspondences.empty() && (point_to_plane_weight > (ScalarT)0.0);
+
+        if ((!has_point_to_point_terms && !has_point_to_plane_terms) ||
+            (has_point_to_plane_terms && dst_p.cols() != dst_n.cols()))
+        {
+            return false;
+        }
+
+        const Vector<ScalarT, 3> dst_mean = dst_p.rowwise().mean();
+        const Vector<ScalarT, 3> src_mean = src_p.rowwise().mean();
+        const auto t_dst = Eigen::Translation<ScalarT, 3>(dst_mean);
+        const auto t_src = Eigen::Translation<ScalarT, 3>(-src_mean);
+
+        Eigen::Matrix<ScalarT,6,6> AtA;
+        Eigen::Matrix<ScalarT,6,1> Atb;
+
+        Eigen::Matrix<ScalarT,3,3> rot_mat_iter;
+        Eigen::Matrix<ScalarT,6,1> d_theta;
+
+        for (size_t iter = 0; iter < max_iter; ++iter) {
+            // Compute differential
+            AtA.setZero();
+            Atb.setZero();
+#ifdef ENABLE_NON_DETERMINISTIC_PARALLELISM
+#pragma omp parallel reduction (internal::MatrixReductions<ScalarT,6,6>::operator+: AtA) reduction (internal::MatrixReductions<ScalarT,6,1>::operator+: Atb)
+#endif
+            {
+                if (has_point_to_point_terms) {
+                    Eigen::Matrix<ScalarT,6,3,Eigen::RowMajor> eq_vecs;
+                    eq_vecs.template bottomRows<3>().setIdentity();
+#ifdef ENABLE_NON_DETERMINISTIC_PARALLELISM
+#pragma omp for nowait
+#endif
+                    for (size_t i = 0; i < point_to_point_correspondences.size(); i++) {
+                        const auto& corr = point_to_point_correspondences[i];
+                        const Vector<ScalarT,3> d = dst_p.col(corr.indexInFirst) - dst_mean;
+                        const ScalarT weight = point_to_point_weight * point_corr_evaluator(corr.indexInFirst, corr.indexInSecond, corr.value);
+                        const Vector<ScalarT,3> s = tform * (src_p.col(corr.indexInSecond) - src_mean);
+
+                        eq_vecs(0,0) = (ScalarT)0.0;
+                        eq_vecs(1,1) = (ScalarT)0.0;
+                        eq_vecs(2,2) = (ScalarT)0.0;
+
+                        eq_vecs(0,1) = -(d[2] + s[2]);
+                        eq_vecs(0,2) = (d[1] + s[1]);
+                        eq_vecs(1,2) = -(d[0] + s[0]);
+
+                        eq_vecs(1,0) = -eq_vecs(0, 1);
+                        eq_vecs(2,0) = -eq_vecs(0, 2);
+                        eq_vecs(2,1) = -eq_vecs(1, 2);
+
+                        AtA += weight * eq_vecs * eq_vecs.transpose();
+                        Atb += weight * eq_vecs * (d - s);
+                    }
+                }
+
+                if (has_point_to_plane_terms) {
+                    Eigen::Matrix<ScalarT,6,1> eq_vec;
+#ifdef ENABLE_NON_DETERMINISTIC_PARALLELISM
+#pragma omp for nowait
+#endif
+                    for (size_t i = 0; i < point_to_plane_correspondences.size(); i++) {
+                        const auto& corr = point_to_plane_correspondences[i];
+                        const ScalarT weight = point_to_plane_weight * plane_corr_evaluator(corr.indexInFirst, corr.indexInSecond, corr.value);
+                        const Vector<ScalarT,3> d = dst_p.col(corr.indexInFirst) - dst_mean;
+                        const Vector<ScalarT,3> n = dst_n.col(corr.indexInFirst) + src_n.col(corr.indexInSecond);
+                        const Vector<ScalarT,3> s = tform * (src_p.col(corr.indexInSecond) - src_mean);
+
+                        eq_vec.template head<3>() = (d + s).cross(n);
+                        eq_vec.template tail<3>() = n;
+
+                        AtA += weight * eq_vec * eq_vec.transpose();
+                        Atb += weight * (n.dot(d - s)) * eq_vec;
+                    }
+                }
+            }
+
+            d_theta.noalias() = AtA.ldlt().solve(Atb);
+
+            // Update estimate
+            ScalarT na = d_theta.template head<3>().norm();
+            ScalarT theta = std::atan(na);
+            const auto Ra = Eigen::AngleAxis<ScalarT>(theta, (1 / na) * d_theta.template head<3>());
+            const auto ta = Eigen::Translation<ScalarT, 3>(std::cos(theta) * d_theta.template tail<3>());
+            tform = t_dst * Ra * ta * Ra * t_src * tform;
+
+            // Check for convergence
+            if (d_theta.norm() < convergence_tol) return true;
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
This PR adds a symmetric version for transformation estimation that uses both source and destination normals and symmetrically splits the transformation being searched for over the source and destination points. It is an implementation of a [paper recently published at SIGGRAPH19](https://gfx.cs.princeton.edu/pubs/Rusinkiewicz_2019_ASO/symm_icp.pdf).

When used in conjunction with ICP it should have faster convergence and a wider convergence basin. To make this useful in cilantro we should add a new ICP method as well.