### PR TITLE
Feature/knn in radius correspondences

### DIFF
--- a/include/cilantro/correspondence_search_kd_tree_utilities.hpp
+++ b/include/cilantro/correspondence_search_kd_tree_utilities.hpp
@@ -22,8 +22,7 @@ namespace cilantro {
         CorrespondenceSet<CorrValueT> corr_tmp(query_pts.cols());
         std::vector<bool> keep(query_pts.cols());
         Neighborhood<ScalarT> nn;
-        if (ref_is_first)
-        {
+        if (ref_is_first) {
 #pragma omp parallel for shared(corr_tmp) private(nn)
             for (size_t i = 0; i < query_pts.cols(); i++) {
                 ref_tree.kNNInRadiusSearch(query_pts.col(i), 1, max_distance, nn);
@@ -31,9 +30,7 @@ namespace cilantro {
                 if (!nn.empty())
                     corr_tmp[i] = {nn[0].index, i, evaluator(nn[0].index, i, nn[0].value)};
             }
-        }
-        else
-        {
+        } else {
 #pragma omp parallel for shared(corr_tmp) private(nn)
             for (size_t i = 0; i < query_pts.cols(); i++) {
                 ref_tree.kNNInRadiusSearch(query_pts.col(i), 1, max_distance, nn);
@@ -46,7 +43,7 @@ namespace cilantro {
         correspondences.resize(corr_tmp.size());
         size_t count = 0;
         for (size_t i = 0; i < corr_tmp.size(); i++) {
-            if (keep[i]) correspondences[count++] = corr_tmp[i];
+            if (keep[i] && corr_tmp[i].value < max_distance) correspondences[count++] = corr_tmp[i];
         }
         correspondences.resize(count);
     }

--- a/include/cilantro/correspondence_search_kd_tree_utilities.hpp
+++ b/include/cilantro/correspondence_search_kd_tree_utilities.hpp
@@ -20,31 +20,33 @@ namespace cilantro {
         }
 
         CorrespondenceSet<CorrValueT> corr_tmp(query_pts.cols());
-
-        Neighbor<ScalarT> nn;
-
-        if (ref_is_first) {
-#pragma omp parallel for shared (corr_tmp) private (nn)
-            for (size_t i = 0; i < corr_tmp.size(); i++) {
-                ref_tree.nearestNeighborSearch(query_pts.col(i), nn);
-                corr_tmp[i].indexInFirst = nn.index;
-                corr_tmp[i].indexInSecond = i;
-                corr_tmp[i].value = evaluator(nn.index, i, nn.value);
+        std::vector<bool> keep(query_pts.cols());
+        Neighborhood<ScalarT> nn;
+        if (ref_is_first)
+        {
+#pragma omp parallel for shared(corr_tmp) private(nn)
+            for (size_t i = 0; i < query_pts.cols(); i++) {
+                ref_tree.kNNInRadiusSearch(query_pts.col(i), 1, max_distance, nn);
+                keep[i] = !nn.empty();
+                if (!nn.empty())
+                    corr_tmp[i] = {nn[0].index, i, evaluator(nn[0].index, i, nn[0].value)};
             }
-        } else {
-#pragma omp parallel for shared (corr_tmp) private (nn)
-            for (size_t i = 0; i < corr_tmp.size(); i++) {
-                ref_tree.nearestNeighborSearch(query_pts.col(i), nn);
-                corr_tmp[i].indexInFirst = i;
-                corr_tmp[i].indexInSecond = nn.index;
-                corr_tmp[i].value = evaluator(i, nn.index, nn.value);
+        }
+        else
+        {
+#pragma omp parallel for shared(corr_tmp) private(nn)
+            for (size_t i = 0; i < query_pts.cols(); i++) {
+                ref_tree.kNNInRadiusSearch(query_pts.col(i), 1, max_distance, nn);
+                keep[i] = !nn.empty();
+                if (!nn.empty())
+                    corr_tmp[i] = {i, nn[0].index, evaluator(i, nn[0].index, nn[0].value)};
             }
         }
 
         correspondences.resize(corr_tmp.size());
         size_t count = 0;
         for (size_t i = 0; i < corr_tmp.size(); i++) {
-            if (corr_tmp[i].value < max_distance) correspondences[count++] = corr_tmp[i];
+            if (keep[i]) correspondences[count++] = corr_tmp[i];
         }
         correspondences.resize(count);
     }


### PR DESCRIPTION
This PR proposes to use `kNNInRadius` neighbors instead nearest neighbors. I haven't tested it through but an ICP run seems to be around 30-40% faster.

There is a slight shortcut here in the fact that we pass `max_distance` as max radius for the search. Before `max_distance` was only used after applying `evaluator` to the correspondence.