### PR TITLE
Transformation estimation fixes and improvements

### DIFF
--- a/include/cilantro/registration/icp_single_transform_combined_metric.hpp
+++ b/include/cilantro/registration/icp_single_transform_combined_metric.hpp
@@ -137,10 +137,10 @@ namespace cilantro {
                 estimateTransformCombinedMetric(dst_points_, dst_normals_, src_points_trans_, corr_getter_proxy.getPointToPointCorrespondences(), point_to_point_weight_, corr_getter_proxy.getPointToPlaneCorrespondences(), point_to_plane_weight_, tform_iter, max_optimization_iterations_, optimization_convergence_tol_, point_corr_eval_, plane_corr_eval_, dst_mean_, this->transform_*src_mean_);
             }
 
-            this->transform_ = tform_iter*this->transform_;
             if (int(Base::Transform::Mode) == int(Eigen::Isometry)) {
-                this->transform_.linear() = this->transform_.rotation();
+                tform_iter.linear() = tform_iter.rotation();
             }
+            this->transform_ = tform_iter*this->transform_;
             this->last_delta_norm_ = std::sqrt((tform_iter.linear() - TransformT::LinearMatrixType::Identity()).squaredNorm() + tform_iter.translation().squaredNorm());
         }
 
@@ -152,10 +152,10 @@ namespace cilantro {
 
             estimateTransformCombinedMetric(dst_points_, dst_normals_, src_points_trans_, corr_getter_proxy.getPointToPointCorrespondences(), point_to_point_weight_, corr_getter_proxy.getPointToPlaneCorrespondences(), point_to_plane_weight_, tform_iter, max_optimization_iterations_, optimization_convergence_tol_, point_corr_eval_, plane_corr_eval_, dst_mean_, this->transform_*src_mean_);
 
-            this->transform_ = tform_iter*this->transform_;
             if (int(Base::Transform::Mode) == int(Eigen::Isometry)) {
-                this->transform_.linear() = this->transform_.rotation();
+                tform_iter.linear() = tform_iter.rotation();
             }
+            this->transform_ = tform_iter*this->transform_;
             this->last_delta_norm_ = std::sqrt((tform_iter.linear() - TransformT::LinearMatrixType::Identity()).squaredNorm() + tform_iter.translation().squaredNorm());
         }
 

--- a/include/cilantro/registration/icp_single_transform_combined_metric.hpp
+++ b/include/cilantro/registration/icp_single_transform_combined_metric.hpp
@@ -125,7 +125,7 @@ namespace cilantro {
 
         // Symmetric metric is only implemented for the rigid 3D case
         template <typename TformT = TransformT>
-        typename std::enable_if<int(TformT::Mode) == int(Eigen::Isometry) && TformT::Dim == 3,void>::type updateEstimate() {
+        typename std::enable_if<int(TformT::Mode) == int(Eigen::Isometry) && (TformT::Dim == 3 || TformT::Dim == 2),void>::type updateEstimate() {
             transformPoints(this->transform_, src_points_, src_points_trans_);
             CorrespondenceSearchCombinedMetricAdaptor<CorrespondenceSearchEngineT> corr_getter_proxy(this->correspondence_search_engine_);
             TransformT tform_iter;
@@ -145,7 +145,7 @@ namespace cilantro {
         }
 
         template <typename TformT = TransformT>
-        typename std::enable_if<int(TformT::Mode) != int(Eigen::Isometry) || TformT::Dim != 3,void>::type updateEstimate() {
+        typename std::enable_if<int(TformT::Mode) != int(Eigen::Isometry) || (TformT::Dim != 3 && TformT::Dim != 2),void>::type updateEstimate() {
             transformPoints(this->transform_, src_points_, src_points_trans_);
             CorrespondenceSearchCombinedMetricAdaptor<CorrespondenceSearchEngineT> corr_getter_proxy(this->correspondence_search_engine_);
             TransformT tform_iter;

--- a/include/cilantro/registration/icp_single_transform_point_to_point_metric.hpp
+++ b/include/cilantro/registration/icp_single_transform_point_to_point_metric.hpp
@@ -44,10 +44,10 @@ namespace cilantro {
             TransformT tform_iter;
             estimateTransformPointToPointMetric(dst_points_, src_points_trans_, corr_getter_proxy.getPointToPointCorrespondences(), tform_iter);
 
-            this->transform_ = tform_iter*this->transform_;
             if (int(Base::Transform::Mode) == int(Eigen::Isometry)) {
-                this->transform_.linear() = this->transform_.rotation();
+                tform_iter.linear() = tform_iter.rotation();
             }
+            this->transform_ = tform_iter*this->transform_;
             this->last_delta_norm_ = std::sqrt((tform_iter.linear() - TransformT::LinearMatrixType::Identity()).squaredNorm() + tform_iter.translation().squaredNorm());
         }
 

--- a/include/cilantro/registration/transform_estimation.hpp
+++ b/include/cilantro/registration/transform_estimation.hpp
@@ -669,12 +669,15 @@ DECLARE_MATRIX_SUM_REDUCTION(ScalarT,6,1)
             ScalarT theta = std::atan(na);
             const Eigen::AngleAxis<ScalarT> Ra(theta, (1 / na) * d_theta.template head<3>());
             const Eigen::Translation<ScalarT, 3> ta(std::cos(theta) * d_theta.template tail<3>());
-            tform = t_dst * Ra * ta * Ra * t_src * tform;
+            tform = Ra * ta * Ra * tform;
 
             // Check for convergence
-            if (d_theta.norm() < convergence_tol) return true;
+            if (d_theta.norm() < convergence_tol) {
+                tform = t_dst * tform * t_src;
+                return true;
+            }
         }
-
+        tform = t_dst * tform * t_src;
         return false;
     }
 }


### PR DESCRIPTION
- Fixes that the iterations for symmetric estimation do not convergence due to centering.
- Adds a 2d symmetric transformation estimation.
- Refactors existing combined estimation implementation to a symmetric formulation which should have a smaller linearization error.
- In order to also estimate reflections with ICP, the isometry condition is now applied to the incremental transform. This allows the initial transform to be a reflection. The caller is now responsible for passing a valid isometry.

Please test thoroughly before merging :)