### PR TITLE
(Robust) covariance

### DIFF
--- a/examples/robust_normal_estimation.cpp
+++ b/examples/robust_normal_estimation.cpp
@@ -1,0 +1,72 @@
+// #include <cilantro/core/normal_estimation.hpp>
+#include <cilantro/utilities/point_cloud.hpp>
+#include <cilantro/visualization.hpp>
+#include <cilantro/utilities/timer.hpp>
+
+void toggle_invalid(cilantro::Visualizer &viz) {
+    viz.getObject("cloud_i")->toggleVisibility();
+}
+
+
+cilantro::PointCloud3f invalidNormalsCloud(const cilantro::PointCloud3f& cloud) {
+    std::vector<size_t> ind_to_remove;
+    ind_to_remove.reserve(cloud.normals.cols());
+    for (size_t i = 0; i < cloud.normals.cols(); i++) {
+        if (!cloud.normals.col(i).allFinite()) ind_to_remove.emplace_back(i);
+    }
+    cilantro::PointCloud3f invalid_cloud(cloud, ind_to_remove);
+    invalid_cloud.normals.resize(Eigen::NoChange, 0);
+    return invalid_cloud;
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 2) {
+        std::cout << "Please provide path to PLY file." << std::endl;
+        return 0;
+    }
+
+    cilantro::PointCloud3f cloud(argv[1]);
+
+    if (cloud.isEmpty()) {
+        std::cout << "Input cloud is empty!" << std::endl;
+        return 0;
+    }
+
+    // Clear input normals
+    cloud.normals.resize(Eigen::NoChange, 0);
+
+    cloud.gridDownsample(0.005f);
+
+    cilantro::Timer tree_timer;
+    tree_timer.start();
+    cilantro::KDTree3f tree(cloud.points);
+    tree_timer.stop();
+
+    cilantro::Timer ne_timer;
+    ne_timer.start();
+    cilantro::NormalEstimation<float, 3, size_t, cilantro::MinimumCovarianceDeterminant<float, 3>> ne(tree);
+    ne.getCovarianceMethod().setChiSquareThreshold(6.25).setNumberOfTrials(2).setNumberOfRefinements(1);  // 90% confidence ellipsoid
+    cloud.normals = ne.getNormalsKNN(12);
+
+    cilantro::PointCloud3f invalid_cloud = invalidNormalsCloud(cloud);
+    cloud.removeInvalidNormals();
+
+    ne_timer.stop();
+
+    std::cout << "kd-tree time: " << tree_timer.getElapsedTime() << "ms" << std::endl;
+    std::cout << "Estimation time: " << ne_timer.getElapsedTime() << "ms" << std::endl;
+
+    cilantro::Visualizer viz("NormalEstimation example", "disp");
+    viz.registerKeyboardCallback('i', std::bind(toggle_invalid, std::ref(viz)));
+
+    viz.addObject<cilantro::PointCloudRenderable>("cloud_d", cloud, cilantro::RenderingProperties().setDrawNormals(true));
+    viz.addObject<cilantro::PointCloudRenderable>("cloud_i", invalid_cloud, cilantro::RenderingProperties().setPointColor(255, 0, 0));
+
+    std::cout << "Press 'n' to toggle rendering of normals" << std::endl;
+    std::cout << "Press 'i' to toggle rendering of outliers" << std::endl;
+    while (!viz.wasStopped()){
+        viz.spinOnce();
+    }
+
+    return 0;
+}

--- a/include/cilantro/core/covariance.hpp
+++ b/include/cilantro/core/covariance.hpp
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <algorithm>
+#include <limits>
+#include <map>
+
+#include <cilantro/core/data_containers.hpp>
+#include <cilantro/utilities/random.hpp>
+
+namespace cilantro {
+
+    template <typename ScalarT, ptrdiff_t EigenDim>
+    class Covariance {
+    public:
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+        Covariance() = default;
+
+        inline bool operator()(const ConstVectorSetMatrixMap<ScalarT,EigenDim> &points, Vector<ScalarT,EigenDim>& mean, Eigen::Matrix<ScalarT,EigenDim,EigenDim>& cov) const {
+            if (points.cols() < points.rows()) return false;
+            mean = points.rowwise().mean();
+            auto centered = points.rowwise() - mean;  // Lazy evaluation
+            cov.noalias() =  (ScalarT)(1.0)/(points.cols() - 1) * (centered * centered.transpose());
+            return true;
+        }
+
+        template <typename NeighborhoodResultIteratorT>
+        inline bool operator()(const ConstVectorSetMatrixMap<ScalarT,EigenDim> &points, NeighborhoodResultIteratorT begin, NeighborhoodResultIteratorT end, Vector<ScalarT,EigenDim>& mean, Eigen::Matrix<ScalarT,EigenDim,EigenDim>& cov) const {
+            size_t size = std::distance(begin, end);
+            if (size < points.rows()) return false;
+
+            mean.setZero();
+            for (NeighborhoodResultIteratorT it = begin; it != end; ++it) {
+                mean += points.col(it->index);
+            }
+            mean *= (ScalarT)(1.0)/size;
+
+            cov.setZero();
+            for (NeighborhoodResultIteratorT it = begin; it != end; ++it) {
+                auto tmp = points.col(it->index) - mean;
+                cov += tmp*tmp.transpose();
+            }
+            cov *= (ScalarT)(1.0)/(size - 1);
+            return true;
+        }
+
+        template <typename NeighborhoodResultT>
+        inline bool operator()(const ConstVectorSetMatrixMap<ScalarT,EigenDim> &points, const NeighborhoodResultT &nn, Vector<ScalarT,EigenDim>& mean, Eigen::Matrix<ScalarT,EigenDim,EigenDim>& cov) const {
+            return (*this)(points, nn.begin(), nn.end(), mean, cov);
+        }
+    };
+
+    template <typename ScalarT, ptrdiff_t EigenDim, typename CovarianceT=Covariance<ScalarT, EigenDim>>
+    class MinimumCovarianceDeterminant {
+    public:
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+        MinimumCovarianceDeterminant() = default;
+
+        template <typename NeighborhoodResultIteratorT>
+        inline bool operator()(const ConstVectorSetMatrixMap<ScalarT,EigenDim> &points, NeighborhoodResultIteratorT begin, NeighborhoodResultIteratorT end, Vector<ScalarT,EigenDim>& mean, Eigen::Matrix<ScalarT,EigenDim,EigenDim>& cov) const {
+            const int first_idx = begin->index;
+
+            const size_t size = std::distance(begin, end);
+            if (size < points.rows()) return false;
+            if (size == points.rows()) return compute_mean_and_covariance_(points, begin, end, mean, cov);
+
+            random_selector<> random {};
+
+            using NeighborT = typename NeighborhoodResultIteratorT::value_type;
+
+            std::vector<NeighborT> subset(points.rows() + 1);
+            const size_t h = static_cast<size_t>(std::ceil(std::max((ScalarT)0.5, outlier_rate_) * (size + EigenDim + 1)));
+            Vector<ScalarT,EigenDim> best_mean;
+            Eigen::Matrix<ScalarT,EigenDim,EigenDim> best_cov;
+            ScalarT best_determinant = std::numeric_limits<ScalarT>::max();
+            for (int j = 0; j < num_trials_; ++j) {
+                std::generate(subset.begin(), subset.end(), [&begin, &end, &random]() { return *random(begin, end); });
+                compute_mean_and_covariance_(points, subset.begin(), subset.end(), mean, cov);
+                for (int l = 0; l < num_refinements_; ++l) {
+                    std::map<size_t, ScalarT> index_to_distance = mahalanobisDistance(points, begin, end, mean, cov.inverse());
+                    std::partial_sort(begin, begin + h, end, [&index_to_distance](const NeighborT& a, const NeighborT& b) {
+                        return index_to_distance[a.index] < index_to_distance[b.index];
+                    });
+                    compute_mean_and_covariance_(points, begin, begin + h, mean, cov);
+                }
+                ScalarT determinant = cov.determinant();
+                if (determinant < best_determinant) {
+                    best_determinant = determinant;
+                    best_cov = cov;
+                    best_mean = mean;
+                }
+            }
+            mean = best_mean;
+            cov = best_cov;
+            if (chi_square_threshold_ <= 0) return true;
+            auto demeaned = points.col(first_idx) - mean;
+            return demeaned.transpose() * cov.inverse() * demeaned <= chi_square_threshold_;
+        }
+
+        template <typename NeighborhoodResultT>
+        inline bool operator()(const ConstVectorSetMatrixMap<ScalarT,EigenDim> &points, NeighborhoodResultT &nn, Vector<ScalarT,EigenDim>& mean, Eigen::Matrix<ScalarT,EigenDim,EigenDim>& cov) const {
+            return (*this)(points, nn.begin(), nn.end(), mean, cov);
+        }
+
+        inline int getNumberOfTrials() const { return num_trials_; }
+
+        inline MinimumCovarianceDeterminant& setNumberOfTrials(int num_trials) {
+            num_trials_ = num_trials;
+            return *this;
+        }
+
+        inline int getNumberOfRefinements() const { return num_refinements_; }
+
+        inline MinimumCovarianceDeterminant& setNumberOfRefinements(int num_refinements) {
+            num_refinements_ = num_refinements;
+            return *this;
+        }
+
+        inline ScalarT getOutlierRate() const { return outlier_rate_; }
+
+        inline MinimumCovarianceDeterminant& setOutlierRate(int outlier_rate) {
+            outlier_rate_ = outlier_rate;
+            return *this;
+        }
+
+        inline ScalarT getChiSquareThreshold() const { return chi_square_threshold_; }
+
+        inline MinimumCovarianceDeterminant& setChiSquareThreshold(int chi_square_threshold) {
+            chi_square_threshold_ = chi_square_threshold;
+            return *this;
+        }
+
+    protected:
+        template <typename NeighborhoodResultIteratorT>
+        std::map<size_t, ScalarT> mahalanobisDistance(const ConstVectorSetMatrixMap<ScalarT,EigenDim> &points, NeighborhoodResultIteratorT begin, NeighborhoodResultIteratorT end, const Vector<ScalarT,EigenDim> &mean, const Eigen::Matrix<ScalarT,EigenDim,EigenDim> &cov_inverse) const {
+            std::map<size_t, ScalarT> index_to_distance;
+            std::transform(begin, end, std::inserter(index_to_distance, index_to_distance.begin()), [&points, &mean, &cov_inverse](const typename NeighborhoodResultIteratorT::value_type &n) {
+                auto demeaned = points.col(n.index) - mean;
+                return std::make_pair(n.index, demeaned.transpose() * cov_inverse * demeaned);
+            });
+            return index_to_distance;
+        }
+
+        // The number of random trials to take:
+        // Can be estimated as log(1 - P) / log(1 - (1 - e)^dim),
+        // where P is the desired probability to find an outlier free set and e is the outlier rate.
+        int num_trials_ = 6;
+        int num_refinements_ = 3;
+        ScalarT outlier_rate_ = (ScalarT)0.75;
+        // If > 0, the covariance ellipse will be used to label the point as in/outlier.
+        ScalarT chi_square_threshold_ = (ScalarT)-1;
+        CovarianceT compute_mean_and_covariance_;
+    };
+}

--- a/include/cilantro/core/covariance.hpp
+++ b/include/cilantro/core/covariance.hpp
@@ -69,8 +69,9 @@ namespace cilantro {
 
             using NeighborT = typename NeighborhoodResultIteratorT::value_type;
 
-            std::vector<NeighborT> subset(points.rows() + 1);
-            const size_t h = static_cast<size_t>(std::ceil(std::max((ScalarT)0.5, outlier_rate_) * (size + EigenDim + 1)));
+            std::vector<NeighborT> subset(points.rows());
+            size_t h = static_cast<size_t>(std::ceil(outlier_rate_ * (size + EigenDim + 1)));
+            if (h > size) h = size - 1;
             Vector<ScalarT,EigenDim> best_mean;
             Eigen::Matrix<ScalarT,EigenDim,EigenDim> best_cov;
             ScalarT best_determinant = std::numeric_limits<ScalarT>::max();
@@ -120,7 +121,7 @@ namespace cilantro {
         inline ScalarT getOutlierRate() const { return outlier_rate_; }
 
         inline MinimumCovarianceDeterminant& setOutlierRate(int outlier_rate) {
-            outlier_rate_ = outlier_rate;
+            outlier_rate_ = std::max((ScalarT)0.5, outlier_rate);
             return *this;
         }
 

--- a/include/cilantro/utilities/random.hpp
+++ b/include/cilantro/utilities/random.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <iterator>
+#include <random>
+
+namespace cilantro {
+
+// Copied from https://gist.github.com/cbsmith/5538174
+template <typename RandomGenerator = std::default_random_engine>
+struct random_selector {
+  // On most platforms, you probably want to use
+  // std::random_device("/dev/urandom")()
+  random_selector(RandomGenerator g = RandomGenerator(std::random_device()()))
+      : gen(g) {}
+
+  template <typename Iter>
+  Iter select(Iter start, Iter end) {
+    std::uniform_int_distribution<> dis(0, std::distance(start, end) - 1);
+    std::advance(start, dis(gen));
+    return start;
+  }
+
+  template <typename Iter>
+  Iter operator()(Iter start, Iter end) {
+    return select(start, end);
+  }
+
+  // Convenience function that works on anything with a sensible begin() and
+  // end(), and returns with a ref to the value type
+  template <typename Container>
+  auto operator()(const Container& c) -> decltype(*begin(c))& {
+    return *select(begin(c), end(c));
+  }
+
+ private:
+  RandomGenerator gen;
+};
+
+}  // namespace cilantro


### PR DESCRIPTION
This PR factors out the computation of the covariance from normal estimation such that alternative methods can be plugged in.
I implemented one alternative based on the minimum covariance determinant (see [Hubert, Debruyne, 2009](https://wis.kuleuven.be/stat/robust/papers/2010/wire-mcd.pdf) and [Nurunnabi, 2015](https://espace.curtin.edu.au/bitstream/handle/20.500.11937/15731/227817_227817.pdf)). Unfortunately, the method is rather slow as you can see in the added example.

There are still some stability issues, so it's still a draft. I'll mark it for review when I've resolved the issues.